### PR TITLE
Add NewLock method to Conn. Add Locker interface.

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -918,3 +918,7 @@ func (c *Conn) Multi(ops MultiOps) error {
 	_, err := c.request(opMulti, req, res, nil)
 	return err
 }
+
+func (c *Conn) NewLock(path string, acl []ACL) Locker {
+	return NewLock(c, path, acl)
+}

--- a/zk/lock.go
+++ b/zk/lock.go
@@ -14,6 +14,13 @@ var (
 	ErrLockTimeout = errors.New("zk: timeout trying to acquire lock")
 )
 
+type Locker interface {
+	Lock() error
+	Unlock() error
+	SetTTL(time.Duration)
+	SetTimeout(time.Duration)
+}
+
 type Lock struct {
 	c                  *Conn
 	path               string


### PR DESCRIPTION
The proposed changes make it easier to mock locking with ZooKeeper by hiding the actual connection behind an interface and making all calls, e.g. `NewLock`, against this interface.
